### PR TITLE
Fixed call to ii.format without force argument

### DIFF
--- a/dnload/glsl_block_default.py
+++ b/dnload/glsl_block_default.py
@@ -19,7 +19,7 @@ class GlslBlockDefault(GlslBlock):
       if isinstance(ii, str):
         ret += [ii]
       else:
-        ret += [ii.format()]
+        ret += [ii.format(force)]
     return " ".join(ret)
 
   def __str__(self):

--- a/dnload/glsl_type.py
+++ b/dnload/glsl_type.py
@@ -20,7 +20,7 @@ class GlslType:
 
   def isVectorType(self):
     """Tell if this is a vector type (eglible for swizzling)."""
-    if re.match(r'^(ivec\d|vec\d)$', self.__type):
+    if re.match(r'^(uvec\d|ivec\d|vec\d)$', self.__type):
       return True
     return False
 
@@ -53,7 +53,7 @@ g_type_modifiers = (
 
 def match_type_id(op):
   """Tell if given string matches a type."""
-  if re.match(r'^(bool|float|int|ivec\d|mat\d|sampler\dD|samplerCube|vec\d|void)$', op):
+  if re.match(r'^(bool|float|int|uint|uvec\d|ivec\d|mat\d|[iu]?sampler\dD|samplerCube|vec\d|void)$', op):
     return True
   return False
 


### PR DESCRIPTION
Bumped into this when trying to run dnload on a single fragment shader. After fixing this dnload returns a somewhat minified shader for me but still gives me a warning: 
`WARNING: returning default GLSL block: '<map object at 0x7f112f00eda0>' `