### PR TITLE
expand OS-detection for Arch-Linux derivatives

### DIFF
--- a/dnload/platform_var.py
+++ b/dnload/platform_var.py
@@ -49,9 +49,9 @@ class PlatformVar:
 
 def determine_platform():
     """Determines the current platform."""
-    (osname, osignore1, osignore2, osversion, osarch, osignore3) = platform.uname()
+    (osname, _, osrelease, osversion, osarch, _) = platform.uname()
     # Linux distributions may have more accurate rules than just being Linux.
-    if re.search(r'[-\s^]arch[-\s$]', osversion, re.I):
+    if re.search(r'(arch|manjaro|antergos)', osversion + osarch, re.I):
         osname = "Arch"
     return (osname, osarch)
 


### PR DESCRIPTION
Hello. First things first, really great work, absolutely liking it! Thank you very much :)
### Intention
As you already integrated support for Arch-linux, this PR aims to make Arch-derivatives (namely Manjaro and Antergos as the most popular ones, though any Distro with "arch" in its name should work) treated the same way as Arch itself and is actually just a two-liner. I also changed two unused variables to the python-supported DontCare variable-name `_` . Please note that I only tested with Manjaro, as this is my specific usecase.
### Testing
![testing](https://user-images.githubusercontent.com/46794176/53291409-13a89600-37b3-11e9-95ae-29ec9960f68e.png)