### PR TITLE
Add support for GLSL layout(binding)

### DIFF
--- a/dnload/glsl_block_layout.py
+++ b/dnload/glsl_block_layout.py
@@ -36,7 +36,7 @@ def glsl_parse_layout(source):
         return (None, source)
     lst = []
     while scope:
-        (location, assignment, index, intermediate) = extract_tokens(scope, ("?|location|binding", "?=", "?u"))
+        (location, assignment, index, intermediate) = extract_tokens(scope, ("?|binding|location", "?=", "?u"))
         if location and assignment and index:
             lst += [[location, assignment, index]]
             scope = intermediate

--- a/dnload/glsl_block_layout.py
+++ b/dnload/glsl_block_layout.py
@@ -36,7 +36,7 @@ def glsl_parse_layout(source):
         return (None, source)
     lst = []
     while scope:
-        (location, assignment, index, intermediate) = extract_tokens(scope, ("?|location", "?=", "?u"))
+        (location, assignment, index, intermediate) = extract_tokens(scope, ("?|location|binding", "?=", "?u"))
         if location and assignment and index:
             lst += [[location, assignment, index]]
             scope = intermediate

--- a/dnload/glsl_name.py
+++ b/dnload/glsl_name.py
@@ -112,6 +112,7 @@ g_locked = (
     "acos",
     "asin",
     "atan",
+    "binding",
     "break",
     "ceil",
     "clamp",


### PR DESCRIPTION
I found that dnload was missing support for `layout(binding=0)` for texture/buffer bindings, which I needed for my use case.
Prior to this patch, it'll emit a `RuntimeError: unknown layout directive <map object at ...>` error when encountering such a directive.

I'm not sure if this change is the "correct" way to implement this, but it appears to Work On My Machine™️ at least.