### PR TITLE
Fix accessors not working with renaming

### DIFF
--- a/dnload/glsl_block.py
+++ b/dnload/glsl_block.py
@@ -1,5 +1,6 @@
 import re
 
+from dnload.common import listify
 from dnload.common import is_listing
 from dnload.glsl_access import interpret_access
 from dnload.glsl_access import is_glsl_access
@@ -52,7 +53,7 @@ class GlslBlock:
     def addChildren(self, lst, prepend=False):
         """Add another block as a child of this."""
         if not is_listing(lst):
-            self.addChildren([lst], prepend)
+            self.addChildren(listify(lst), prepend)
             return
         for ii in lst:
             if not is_glsl_block(ii):

--- a/dnload/glsl_block_assignment.py
+++ b/dnload/glsl_block_assignment.py
@@ -103,11 +103,15 @@ def glsl_parse_assignment(source, explicit=True):
     while True:
         (index_scope, remaining) = extract_tokens(content, ("?[",))
         # Index scope may be empty, mut may not be None.
-        if not index_scope is None:
-            (index_scope_statements, discard) = glsl_parse_statements(index_scope)
-            if not index_scope_statements:
-                raise RuntimeError("parsing indexing scope statements failed")
-            modifiers += [GlslParen("[")] + index_scope_statements + [GlslParen("]")]
+        if not (index_scope is None):
+            # Non-empty scope must be parsed into statements.
+            if index_scope:
+                (index_scope_statements, discard) = glsl_parse_statements(index_scope)
+                if not index_scope_statements:
+                    raise RuntimeError("parsing indexing scope statements failed")
+                modifiers += [GlslParen("[")] + index_scope_statements + [GlslParen("]")]
+            else:
+                modifiers += [GlslParen("[")] + [GlslParen("]")]
             content = remaining
             continue
         (access, remaining) = extract_tokens(content, ("?a",))

--- a/dnload/glsl_block_inout.py
+++ b/dnload/glsl_block_inout.py
@@ -87,8 +87,8 @@ class GlslBlockInOutStruct(GlslBlockInOut):
         """Accessor."""
         return self.__type_name
 
-    def isMergableWith(self, op):
-        """Tell if this inout block can be merged with given block."""
+    def isCompatibleWith(self, op):
+        """Tell if this inout block is compatible (member-wise) with given block."""
         if not is_glsl_block_inout_struct(op):
             return False
         if self.getTypeName() != op.getTypeName():
@@ -101,6 +101,14 @@ class GlslBlockInOutStruct(GlslBlockInOut):
             if ii.getName() != jj.getName():
                 return False
         return True
+
+    def isMergableWith(self, op):
+        """Tell if this inout block can be merged with given block."""
+        if not is_glsl_block_inout_struct(op):
+            return False
+        if self.getName() != op.getName():
+            return False
+        return self.isCompatibleWith(op)
 
     def setMemberAccesses(self, lst):
         """Set collected member accesses."""

--- a/dnload/glsl_name_strip.py
+++ b/dnload/glsl_name_strip.py
@@ -38,45 +38,6 @@ class GlslNameStrip:
         for ii in self.__names:
             op.addName(ii)
 
-    def collectMemberAccesses(self):
-        """Collect all member name accesses from the blocks."""
-        # First, collect all uses from members.
-        uses = {}
-        for ii in self.__blocks:
-            collect_member_uses(ii, uses)
-        # Then collect all uses from names.
-        for ii in self.__names:
-            aa = ii.getAccess()
-            # Might be just declaration.
-            if not aa:
-                continue
-            aa.disableSwizzle()
-            name_object = aa.getName()
-            name_string = name_object.getName()
-            if not (name_string in uses):
-                raise RuntimeError("access '%s' not present outside members" % (str(aa)))
-            uses[name_string] += [name_object]
-        # Expand uses, set types and sort.
-        ret = []
-        for kk in uses.keys():
-            name_list = uses[kk]
-            if 1 >= len(name_list):
-                print("WARNING: member '%s' of '%s' not accessed" % (name_list[0].getName(), str(block)))
-            typeid = name_list[0].getType()
-            if not typeid:
-                raise RuntimeError("name '%s' has no type" % (name_list[0]))
-            for ii in name_list[1:]:
-                current_typeid = ii.getType()
-                # Check that there is no conflicting type.
-                if current_typeid:
-                    if current_typeid != typeid:
-                        raise RuntimeError("member access %s type %s does not match base type %s" % (str(ii), str(current_typeid), str(typeid)))
-                    continue
-                # No existing type, fill it in.
-                ii.setType(typeid)
-            ret += [name_list]
-        return sorted(ret, key=len, reverse=True)
-
     def getBlock(self):
         """Gets the block that declared the original name."""
         return self.__blocks[0]
@@ -134,16 +95,6 @@ class GlslNameStrip:
 ########################################
 # Functions ############################
 ########################################
-
-def collect_member_uses(block, uses):
-    """Collect member uses from inout struct block."""
-    for ii in block.getMembers():
-        name_object = ii.getName()
-        name_string = name_object.getName()
-        if name_string in uses:
-            uses[name_string] += [name_object]
-        else:
-            uses[name_string] = [name_object]
 
 def is_glsl_name_strip(op):
     """Tells if given object is a GLSL name strip."""


### PR DESCRIPTION
Accessors were not parsed as `GlslStatement`s, and could thus not be searched for names.
Differently named `GlslBlockInoutStruct`s were not considered compatible. This meant their members were renamed separately. This broke compilation of Primordial Soup, and I don't really know for how long it had been broken.