### PR TITLE
Fix numerous simplification pass errors

### DIFF
--- a/dnload/glsl_block.py
+++ b/dnload/glsl_block.py
@@ -4,6 +4,8 @@ from dnload.common import listify
 from dnload.common import is_listing
 from dnload.glsl_access import interpret_access
 from dnload.glsl_access import is_glsl_access
+from dnload.glsl_bool import interpret_bool
+from dnload.glsl_bool import is_glsl_bool
 from dnload.glsl_control import interpret_control
 from dnload.glsl_control import is_glsl_control
 from dnload.glsl_int import interpret_int
@@ -487,6 +489,12 @@ def tokenize_interpret(tokens):
             ret += [terminator]
             ii += 1
             continue
+        # Booleans look like names.
+        boolean = interpret_bool(element)
+        if boolean:
+            ret += [boolean]
+            ii += 1
+            continue
         # Try name identifier last.
         name = interpret_name(element)
         if name:
@@ -515,13 +523,17 @@ def tokenize_split(source):
 
 def validate_token(token, validation):
     """Validate that token matches given requirement."""
-    # Unsigned int.
-    if "u" == validation:
-        if not is_glsl_int_unsigned(token):
+    # Bool.
+    if "b" == validation:
+        if not is_glsl_bool(token):
             return None
     # Int.
     elif "i" == validation:
         if not is_glsl_int(token):
+            return None
+    # Unsigned int.
+    elif "u" == validation:
+        if not is_glsl_int_unsigned(token):
             return None
     # Float.
     elif "f" == validation:

--- a/dnload/glsl_block_statement.py
+++ b/dnload/glsl_block_statement.py
@@ -5,6 +5,7 @@ from dnload.glsl_block import GlslBlock
 from dnload.glsl_block import extract_tokens
 from dnload.glsl_paren import GlslParen
 from dnload.glsl_paren import is_glsl_paren
+from dnload.glsl_token import token_list_create
 from dnload.glsl_token import token_tree_build
 from dnload.glsl_token import token_tree_simplify
 from dnload.glsl_operator import is_glsl_operator
@@ -149,7 +150,7 @@ def simplify_pass(lst):
     """Run simplification pass on tokens."""
     # Build tree and run simplify pass from there.
     if lst:
-        tree = token_tree_build(lst)
+        tree = token_tree_build(token_list_create(lst))
         if not tree:
             raise RuntimeError("could not build tree from '%s'" % (str(map(str, lst))))
         if token_tree_simplify(tree):

--- a/dnload/glsl_block_statement.py
+++ b/dnload/glsl_block_statement.py
@@ -82,10 +82,12 @@ class GlslBlockStatement(GlslBlock):
         while True:
             if (max_simplifys >= 0) and (max_simplifys <= ret):
                 break
-            content = simplify_pass(self.__content)
+            (content, simplified) = simplify_pass(self.__content)
             if not content and self.__content:
                 raise RuntimeError("content '%s' simplified to '%s'" % (str(map(str, self.__content)), str(content)))
-            if content == self.__content:
+            if not simplified:
+                if content != self.__content:
+                    raise RuntimeError("content differs even if simplification was supposedly not made")
                 break
             self.__content = content
             self.clearAccesses()
@@ -154,6 +156,6 @@ def simplify_pass(lst):
         if not tree:
             raise RuntimeError("could not build tree from '%s'" % (str(map(str, lst))))
         if token_tree_simplify(tree):
-            return tree.flatten()
+            return (tree.flatten(), True)
     # Nothign to simplify, just return original tree.
-    return lst
+    return (lst, False)

--- a/dnload/glsl_bool.py
+++ b/dnload/glsl_bool.py
@@ -1,0 +1,49 @@
+import re
+
+########################################
+# GlslBool #############################
+########################################
+
+class GlslBool:
+    """GLSL boolean."""
+
+    def __init__(self, source):
+        """Constructor."""
+        if source == "true":
+            self.__string = source
+            self.__number = True
+        elif source == "false":
+            self.__string = source
+            self.__number = False
+        else:
+            raise RuntimeError("not a GLSL boolean string: '%s'" % (source))
+
+    def format(self, force):
+        """Return formatted output."""
+        return str(self.__string)
+
+    def getBool(self):
+        """Integer representation."""
+        return self.__number
+
+    def requiresTruncation(self):
+        """Does this number require truncation?"""
+        return False
+
+    def __str__(self):
+        """String representation."""
+        return "GlslBool('%s')" % (self.__string)
+
+########################################
+# Functions ############################
+########################################
+
+def interpret_bool(source):
+    """Try to interpret boolean."""
+    if re.match(r'^(false|true)$', source):
+        return GlslBool(source)
+    return None
+
+def is_glsl_bool(op):
+    """Tell if token is integer."""
+    return isinstance(op, GlslBool)

--- a/dnload/glsl_float.py
+++ b/dnload/glsl_float.py
@@ -37,6 +37,10 @@ class GlslFloat:
         """Accessor."""
         return self.__number
 
+    def getNegatedNumber(self):
+        """Get negated version of the content."""
+        return GlslFloat(self.__integer1.getNegatedNumber(), self.__integer2)
+
     def getPrecision(self):
         """Get precision - number of numbers to express."""
         return self.__integer1.getPrecision() + self.__integer2.getPrecision()

--- a/dnload/glsl_int.py
+++ b/dnload/glsl_int.py
@@ -32,6 +32,12 @@ class GlslInt:
         """Integer representation."""
         return self.__number
 
+    def getNegatedNumber(self):
+        """Get negated version of the content."""
+        if self.__sign == "-":
+            return GlslInt(str(self.__string))
+        return GlslInt("-" + self.__string)
+
     def getPrecision(self):
         """Get precision - number of numbers to express."""
         return len(self.__string.strip("+-0"))

--- a/dnload/glsl_name.py
+++ b/dnload/glsl_name.py
@@ -127,7 +127,6 @@ g_locked = (
         "EmitVertex",
         "EndPrimitive",
         "exp",
-        "false",
         "floor",
         "fract",
         "gl_FragDepth",
@@ -160,7 +159,6 @@ g_locked = (
         "step",
         "tan",
         "tanh",
-        "true",
         "uniform",
         )
 

--- a/dnload/glsl_operator.py
+++ b/dnload/glsl_operator.py
@@ -11,14 +11,32 @@ class GlslOperator:
 
     def applyOperator(self, lhs, rhs):
         """Apply mathematical operator for given left and right operand."""
-        if self.__operator == "*":
-            return lhs * rhs
-        elif self.__operator == "/":
-            return lhs / rhs
-        elif self.__operator == "+":
+        if self.__operator == "+":
             return lhs + rhs
         elif self.__operator == "-":
             return lhs - rhs
+        elif self.__operator == "*":
+            return lhs * rhs
+        elif self.__operator == "/":
+            return lhs / rhs
+        elif self.__operator == "%":
+            return lhs % rhs
+        elif self.__operator == "==":
+            return int(lhs == rhs)
+        elif self.__operator == "!=":
+            return int(lhs != rhs)
+        elif self.__operator == "<":
+            return int(lhs < rhs)
+        elif self.__operator == "<=":
+            return int(lhs <= rhs)
+        elif self.__operator == ">":
+            return int(lhs > rhs)
+        elif self.__operator == ">=":
+            return int(lhs >= rhs)
+        elif self.__operator == "&&":
+            return int((lhs != 0) and (rhs != 0))
+        elif self.__operator == "||":
+            return int((lhs != 0) and (rhs != 0))
         raise RuntimeError("don't know how to apply operator '%s'" % (self.__operator))
 
     def format(self, force):
@@ -28,6 +46,14 @@ class GlslOperator:
     def getOperator(self):
         """Get content string."""
         return self.__operator
+
+    def getParamCount(self):
+        """Get the parameter count for operators that can be applied compile-time or None."""
+        if self.__operator in ("-", "+", "*", "/", "%", "==", "!=", "<", "<=", ">", ">=", "&&", "||"):
+            return 2
+        elif self.__operator in ("?",):
+            return 3
+        return None
 
     def getPrecedence(self):
         """Get operator precedence. Lower happens first."""
@@ -68,7 +94,7 @@ class GlslOperator:
         if self.__operator in ("||",):
             return ret
         ret += 1
-        if self.__operator in ("?", ":"):
+        if self.__operator in ("?",":"):
             return ret
         ret += 1
         if self.__operator in ("=", "+=", "-=", "*=", "/=", "|=", "&=", "^="):
@@ -77,10 +103,6 @@ class GlslOperator:
         if self.__operator in (",",):
             return ret
         raise RuntimeError("operator '%s' has no precedence" % (str(self)))
-
-    def isApplicable(self):
-        """Tell if operator can be applied on compile-time."""
-        return self.__operator in ("-", "+", "*", "/", "%")
 
     def isAssignment(self):
         """Tell if this is an assignment operator of any kind."""

--- a/dnload/glsl_operator.py
+++ b/dnload/glsl_operator.py
@@ -22,21 +22,21 @@ class GlslOperator:
         elif self.__operator == "%":
             return lhs % rhs
         elif self.__operator == "==":
-            return int(lhs == rhs)
+            return lhs == rhs
         elif self.__operator == "!=":
-            return int(lhs != rhs)
+            return lhs != rhs
         elif self.__operator == "<":
-            return int(lhs < rhs)
+            return lhs < rhs
         elif self.__operator == "<=":
-            return int(lhs <= rhs)
+            return lhs <= rhs
         elif self.__operator == ">":
-            return int(lhs > rhs)
+            return lhs > rhs
         elif self.__operator == ">=":
-            return int(lhs >= rhs)
+            return lhs >= rhs
         elif self.__operator == "&&":
-            return int((lhs != 0) and (rhs != 0))
+            return (lhs != 0) and (rhs != 0)
         elif self.__operator == "||":
-            return int((lhs != 0) and (rhs != 0))
+            return (lhs != 0) and (rhs != 0)
         raise RuntimeError("don't know how to apply operator '%s'" % (self.__operator))
 
     def format(self, force):

--- a/dnload/glsl_paren.py
+++ b/dnload/glsl_paren.py
@@ -35,6 +35,10 @@ class GlslParen:
         """Tell if this is a curly brace."""
         return self.__paren in ("{", "}")
 
+    def isOpening(self):
+        """Tell if this is an opening paren type."""
+        return self.__paren in ("[", "{", "(")
+
     def isParen(self):
         """Tell if this is a paren."""
         return self.__paren in ("(", ")")

--- a/dnload/glsl_token.py
+++ b/dnload/glsl_token.py
@@ -793,7 +793,7 @@ def token_descend(token):
     return token
 
 def token_list_collapse_negative_numbers(lst):
-    """Collapse negative numbers out from a token list."""
+    """Collapse minuses with numbers into a proper negative numbers as necessary."""
     prev2 = None
     prev2_content = None
     prev1 = None
@@ -824,7 +824,6 @@ def token_list_create(lst):
             ret += [GlslToken(ii)]
         elif ii:
             ret += [ii]
-    # Collapse extra minus operators into negative numbers.
     return token_list_collapse_negative_numbers(ret)
 
 def token_tree_build(lst):


### PR DESCRIPTION
Fix bug that interpreted negative numbers as a separate minus sign and a number during simplification.
Fix bug that prevented integrification of all function parameters.
Fix bug that stopped simplification if there was no immediately apparent changes (i.e. only integrification enabled).
Add `GlslBool` type to allow precalculating operations.
Execute comparison operations that evaluate into a `GlslBool` result.
Execute ternary operators when `:` is parent of `?`.
Execute `float(<int>)` operations.

TODO: Execute ternary operators when `?` is parent of `:`.